### PR TITLE
Deploy to sonatype repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,8 @@ jobs:
       if: (branch = master) AND (type = push)
       deploy:
         provider: script
-        script: ./mvnw deploy -B -P release -s .travis/settings.xml
+        skip_cleanup: true
+        script: ./mvnw deploy -B -P release -s .travis/settings.xml -DskipTests -Dinvoker.skip
         on:
           branch: master
     - script: skip
@@ -27,7 +28,8 @@ jobs:
       if: tag IS present
       deploy:
         provider: script
-        script: ./mvnw deploy -B -P release -s .travis/settings.xml
+        skip_cleanup: true
+        script: ./mvnw deploy -B -P release -s .travis/settings.xml -DskipTests -Dinvoker.skip
         on:
           tags: true
 addons:

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 This Maven Plugin helps developers to run static analysis only for updated codes.
 Designed to use in incremental build, like pre-merge build and local build.
 
+[![Build Status](https://travis-ci.com/WorksApplications/incremental-analysis.svg?branch=master)](https://travis-ci.com/WorksApplications/incremental-analysis)
 [![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
 
 ## How to use

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,9 @@
   <artifactId>incremental-analysis-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>
   <version>0.1.0-SNAPSHOT</version>
-  <name>Maven plugin to generate list of target class to analyze in incremental build</name>
+  <name>Incremental Analysis Maven Plugin</name>
+  <description>Maven plugin to generate list of target class to analyze in incremental build</description>
+  <url>https://github.com/WorksApplications/incremental-analysis</url>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.version>3.3.1</maven.version>
@@ -283,4 +285,23 @@
       <url>https://oss.sonatype.org/content/repositories/snapshots</url>
     </snapshotRepository>
   </distributionManagement>
+  <licenses>
+    <license>
+      <name>The Apache License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+  <developers>
+    <developer>
+      <name>Kengo TODA</name>
+      <email>toda_k@worksap.co.jp</email>
+      <organization>Works Applications Co.,Ltd.</organization>
+      <organizationUrl>https://www.worksap.com/</organizationUrl>
+    </developer>
+  </developers>
+  <scm>
+    <connection>scm:git:git://github.com/WorksApplications/incremental-analysis.git</connection>
+    <developerConnection>scm:git:git://github.com/WorksApplications/incremental-analysis.git</developerConnection>
+    <url>https://github.com/WorksApplications/incremental-analysis/tree/master</url>
+  </scm>
 </project>


### PR DESCRIPTION
[Latest build on master](https://travis-ci.com/WorksApplications/incremental-analysis/builds/101571629) was failed, because `skip_cleanup` is false in each deployment job and it removes decoded files.

We also need to add missing data in `pom.xml`, see https://central.sonatype.org/pages/requirements.html for detail.