### PR TITLE
Multi module support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,38 +8,7 @@ Designed to use in incremental build, like pre-merge build and local build.
 
 ## How to use
 
-### Introduce incremental-analysis plugin to your Maven project
-
-Add the following `<plugin>` element into your `pom.xml`:
-
-```xml
-<plugin>
-  <groupId>com.worksap.tools</groupId>
-  <artifactId>incremental-analysis-maven-plugin</artifactId>
-  <version>1.0.1</version>
-</plugin>
-```
-
-Make sure it runs before the [spotbugs-maven-plugin](https://github.com/spotbugs/spotbugs-maven-plugin/).
-
-### Run incremental analysis in local
-
-By default, this plugin runs to detect changes between your `HEAD` and `refs/heads/master`.
-This fits [the GitHub Flow](https://githubflow.github.io/) and [the GitLab Flow](https://docs.gitlab.com/ee/workflow/gitlab_flow.html).
-
-If you want to full analysis in local, use `<skip>` configuration then Maven run full analysis by default.
-You may overwrite this configuration by profile activated in the CI build.
-
-```xml
-<plugin>
-  <groupId>com.worksap.tools</groupId>
-  <artifactId>incremental-analysis-maven-plugin</artifactId>
-  <version>1.0.1</version>
-  <configuration>
-    <skip>true</skip>
-  </configuration>
-</plugin>
-```
+Refer [this plugin's project documentation](https://worksapplications.github.io/incremental-analysis/plugin-info.html) for detail.
 
 ## Known problems
 

--- a/README.md
+++ b/README.md
@@ -45,10 +45,6 @@ You may overwrite this configuration by profile activated in the CI build.
 
 * No support for checkstyle, PMD and other tools.
 * No support for other programming languages.
-* This version is not marked as thread safe. Current implementation expects that analysis maven plugin runs just after this plugin. For instance, following scenario with two threads may break the build:
-    1. Module A runs incremental-analysis-maven-plugin, and set `spotbugs.skip` as `true`
-    2. Module B runs incremental-analysis-maven-plugin, and set `spotbugs.skip` as `false`
-    3. Module A runs spotbugs-maven-plugin. We expect that Maven skips execution (see 1.) but now `spotbugs.skip` is `false` so it will not be skipped.
 * This plugin does not ensure that the target branch has no potential bugs. It is possible to merge buggy code in several cases:
     1. You added `@CheckForNull` to a method defined in interface. Then SpotBugs may find potential bug in its implementation, but it cannot be found by incremental analysis because it scans updated classes only.
     2. You added `@CheckForNull` to a method. Then SpotBugs may find potential bug in its caller, but it cannot be found by incremental analysis because it scans updated classes only.

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,13 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-site-plugin</artifactId>
           <version>3.7.1</version>
+          <dependencies>
+            <dependency>
+              <groupId>org.apache.maven.doxia</groupId>
+              <artifactId>doxia-module-markdown</artifactId>
+              <version>1.8</version>
+            </dependency>
+          </dependencies>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -251,6 +258,12 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-plugin-plugin</artifactId>
+        <configuration>
+          <requirements>
+            <maven>${maven.version}</maven>
+            <jdk>1.8</jdk>
+          </requirements>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/src/it/multi-module/README.md
+++ b/src/it/multi-module/README.md
@@ -1,0 +1,2 @@
+This project has two submodules.
+We use this to prove that our plugin can support multi module and parallel build.

--- a/src/it/multi-module/invoker.properties
+++ b/src/it/multi-module/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals = clean compile incremental-analysis:spotbugs spotbugs:spotbugs -T 2
+invoker.buildResult = success

--- a/src/it/multi-module/module-1/pom.xml
+++ b/src/it/multi-module/module-1/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.example</groupId>
+    <artifactId>multi-module</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>module-1</artifactId>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.worksap.tools</groupId>
+        <artifactId>incremental-analysis-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/multi-module/module-1/src/main/java/com/example/Main.java
+++ b/src/it/multi-module/module-1/src/main/java/com/example/Main.java
@@ -1,0 +1,7 @@
+package com.example;
+
+public class Main {
+  public static void main(String... args) {
+    System.out.println("Hello, world!");
+  }
+}

--- a/src/it/multi-module/module-2/pom.xml
+++ b/src/it/multi-module/module-2/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.example</groupId>
+    <artifactId>multi-module</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>module-2</artifactId>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.worksap.tools</groupId>
+        <artifactId>incremental-analysis-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/multi-module/module-2/src/main/java/com/example/Main.java
+++ b/src/it/multi-module/module-2/src/main/java/com/example/Main.java
@@ -1,0 +1,7 @@
+package com.example;
+
+public class Main {
+  public static void main(String... args) {
+    System.out.println("Hello, world!");
+  }
+}

--- a/src/it/multi-module/pom.xml
+++ b/src/it/multi-module/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>multi-module</artifactId>
+  <version>0.1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>com.worksap.tools</groupId>
+          <artifactId>incremental-analysis-maven-plugin</artifactId>
+          <version>@project.version@</version>
+        </plugin>
+        <plugin>
+          <groupId>com.github.spotbugs</groupId>
+          <artifactId>spotbugs-maven-plugin</artifactId>
+          <version>3.1.11</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+  <modules>
+    <module>module-1</module>
+    <module>module-2</module>
+  </modules>
+</project>

--- a/src/it/multi-module/postbuild.groovy
+++ b/src/it/multi-module/postbuild.groovy
@@ -1,0 +1,6 @@
+File log = new File(basedir, 'build.log')
+assert log.exists()
+
+assert log.text.contains('No updated Java class found, static analysis will be skipped.')
+assert log.text.contains('Successfully generated list of target classes for SpotBugs.')
+

--- a/src/it/multi-module/prebuild.groovy
+++ b/src/it/multi-module/prebuild.groovy
@@ -1,0 +1,12 @@
+@GrabResolver(name = 'jcenter', root = 'http://jcenter.bintray.com/')
+@Grab('org.ajoberstar.grgit:grgit-core:3.0.0')
+import org.ajoberstar.grgit.Grgit
+
+def git = Grgit.init(dir: basedir)
+
+git.add(patterns: ['pom.xml', 'module-1'])
+git.commit(message: 'initial commit')
+git.checkout(branch: 'feature-branch', createBranch: true)
+git.add(patterns: ['.'])
+git.commit(message: 'second commit')
+git.close()

--- a/src/main/java/com/worksap/tools/spotbugs/maven/incremental/SpotBugsMojo.java
+++ b/src/main/java/com/worksap/tools/spotbugs/maven/incremental/SpotBugsMojo.java
@@ -37,37 +37,10 @@ import org.eclipse.jgit.lib.Constants;
 
 /**
  * A mojo to generate {@code -onlyAnalyze} parameter for spotbugs-maven-plugin. Generated parameter
- * will be set as property of current Maven execution.
+ * will be set as property of current Maven execution.<br>
  *
- * <p>Execute this mojo before you run spotbugs-maven-plugin, then you can check analysis only for
+ * Execute this mojo before you run spotbugs-maven-plugin, then you can check analysis only for
  * updated Java classes.
- *
- * <pre>
- *    &lt;plugin&gt;
- *      &lt;groupId&gt;com.worksap.tools&lt;/groupId&gt;
- *      &lt;artifactId&gt;incremental-analysis-maven-plugin&lt;/artifactId&gt;
- *      &lt;version&gt;1.0.1&lt;/version&gt;
- *      &lt;executions&gt;
- *        &lt;execution&gt;
- *          &lt;phase&gt;verify&lt;/phase&gt;
- *          &lt;goals&gt;
- *            &lt;goal&gt;spotbugs&lt;/goal&gt;
- *          &lt;/goals&gt;
- *        &lt;/execution&gt;
- *      &lt;/executions&gt;
- *    &lt;/plugin&gt;
- *    &lt;plugin&gt;
- *      &lt;groupId&gt;org.codehaus.mojo&lt;/groupId&gt;
- *      &lt;artifactId&gt;spotbugs-maven-plugin&lt;/artifactId&gt;
- *      &lt;executions&gt;
- *        &lt;execution&gt;
- *          &lt;phase&gt;verify&lt;/phase&gt;
- *          &lt;goals&gt;
- *            &lt;goal&gt;spotbugs&lt;/goal&gt;
- *          &lt;/goals&gt;
- *        &lt;/execution&gt;
- *      &lt;/executions&gt;
- *    &lt;/plugin&gt;</pre>
  *
  * @author Kengo TODA (toda_k@worksap.co.jp)
  */
@@ -79,21 +52,36 @@ import org.eclipse.jgit.lib.Constants;
 public class SpotBugsMojo extends AbstractMojo {
   private final GitUpdatedJavaCodeDetector detector;
 
-  @Parameter(property = "project", required = true)
+  @Parameter(property = "project")
   private MavenProject project;
 
+  /**
+   * Name of the property to generate value by this plugin, to specify {@code -onlyAnalyze} option to SpotBugs.
+   */
   @Parameter(defaultValue = "spotbugs.onlyAnalyze")
   private String propertyToAnalyze;
 
+  /**
+   * Name of the property to generate value by this plugin, to decide that spotbugs-maven-plugin needs to skip analysis or not.
+   */
   @Parameter(defaultValue = "spotbugs.skip")
   private String propertyToSkip;
 
+  /**
+   * Git ref of the source of pull-request or merge-request.
+   */
   @Parameter(defaultValue = Constants.HEAD, property = "incremental.spotbugs.source")
   private String source;
 
+  /**
+   * Git ref of the target of pull-request or merge-request.
+   */
   @Parameter(defaultValue = "refs/heads/master", property = "incremental.spotbugs.target")
   private String target;
 
+  /**
+   * Flag to skip execution of this incremental-analysis plugin.
+   */
   @Parameter(defaultValue = "false", property = "incremental.spotbugs.skip")
   private boolean skip;
 

--- a/src/main/java/com/worksap/tools/spotbugs/maven/incremental/SpotBugsMojo.java
+++ b/src/main/java/com/worksap/tools/spotbugs/maven/incremental/SpotBugsMojo.java
@@ -73,7 +73,7 @@ import org.eclipse.jgit.lib.Constants;
  */
 @Mojo(
     name = "spotbugs",
-    threadSafe = false,
+    threadSafe = true,
     requiresProject = true,
     defaultPhase = LifecyclePhase.VERIFY)
 public class SpotBugsMojo extends AbstractMojo {

--- a/src/site/markdown/examples/local.md
+++ b/src/site/markdown/examples/local.md
@@ -1,0 +1,17 @@
+## Run incremental analysis in local
+
+By default, this plugin runs to detect changes between your `HEAD` and `refs/heads/master`.
+This fits [the GitHub Flow](https://githubflow.github.io/) and [the GitLab Flow](https://docs.gitlab.com/ee/workflow/gitlab_flow.html).
+
+If you want to full analysis in local, use `<skip>` configuration then Maven run full analysis by default.
+You may overwrite this configuration by profile activated in the CI build.
+
+```xml
+<plugin>
+  <groupId>com.worksap.tools</groupId>
+  <artifactId>incremental-analysis-maven-plugin</artifactId>
+  <configuration>
+    <skip>true</skip>
+  </configuration>
+</plugin>
+```

--- a/src/site/markdown/examples/maven.md
+++ b/src/site/markdown/examples/maven.md
@@ -1,0 +1,6 @@
+## Run incremental analysis in your Maven project
+
+Refer [the plugin documentation](/plugin-info.html) and modify your `pom.xml` accordingly.
+
+Make sure this plugin is described before the [spotbugs-maven-plugin](https://github.com/spotbugs/spotbugs-maven-plugin/).
+Then spotbugs-maven-plugin can use updated property and run incremental analysis.

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -1,0 +1,4 @@
+## Incremental Analysis Maven Plugin
+
+This Maven Plugin helps developers to run static analysis only for updated codes.
+Designed to use in incremental build, like pre-merge build and local build.

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -33,6 +33,10 @@ limitations under the License.
       <item name="Introduction" href="index.html"/>
       <item name="Goals" href="plugin-info.html"/>
     </menu>
+    <menu name="Examples">
+      <item name="Run incremental analysis in your Maven project" href="examples/maven.html"/>
+      <item name="Run incremental analysis in local" href="examples/local.html"/>
+    </menu>
     <menu ref="reports"/>
   </body>
   <custom>


### PR DESCRIPTION
Add an integration-test to prove that this plugin can support multi-module and parallel build.
I've confirmed that the worry described in README doesn't exist any more.

```
       |   [INFO] --- incremental-analysis-maven-plugin:1.0.1:spotbugs (default-cli) @ module-2 ---
       |   [INFO] 
       |   [INFO] --- incremental-analysis-maven-plugin:1.0.1:spotbugs (default-cli) @ module-1 ---
       |   [INFO] Start generating list of target classes for SpotBugs...
       |   [INFO] Start generating list of target classes for SpotBugs...
       |   [INFO] No updated Java class found, static analysis will be skipped.
       |   [INFO] 
       |   [INFO] --- spotbugs-maven-plugin:3.1.11:spotbugs (default-cli) @ module-1 ---
       |   [INFO] Successfully generated list of target classes for SpotBugs.
       |   [INFO] 
       |   [INFO] --- spotbugs-maven-plugin:3.1.11:spotbugs (default-cli) @ module-2 ---
       |   [INFO] Fork Value is true
       |   [INFO] Done SpotBugs Analysis....
```

This PR also improve documentation.